### PR TITLE
More specific return values from test_credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Simply run `make`.
 
 % Test credentials
 4> mojoauth:test_credentials([{username, "1412629132:foobar"}, {password,<<"Q1RegXu0oYtm1UYqxRkegilugeM=">>}], Secret).
-"foobar"
+{ok,"foobar"}
 5> mojoauth:test_credentials([{username, "1412629132:foobar"}, {password,"wrongpassword"}], Secret).
-false
+{invalid}
 
 % 1 day later
 6> mojoauth:test_credentials([{username, "1412629132:foobar"}, {password,<<"Q1RegXu0oYtm1UYqxRkegilugeM=">>}], Secret).
-false
+{expired}
 ```
 
 ## Contributing

--- a/src/mojoauth.erl
+++ b/src/mojoauth.erl
@@ -33,7 +33,7 @@ create_credentials({id, Id}, {ttl, Ttl}, {secret, Secret}) ->
   Timestamp = Mega*1000000 + Secs + Ttl,
   Username = string:join([integer_to_list(Timestamp), Id], ":"),
   [
-    {username, Username},
+    {username, list_to_binary(Username)},
     {password, sign(Username, Secret)}
   ].
 
@@ -50,8 +50,8 @@ create_credentials({secret, Secret}) ->
 %% @spec test_credentials(Credential::credential(), secret()) -> any()
 %% @doc Test a set of credentials are valid for the given secret. When an identity is asserted, the identity is returned as a string, otherwise a boolean is returned.
 test_credentials([{username, Username}, {password, Password}], Secret) ->
-  RetVal = case string:tokens(Username, ":") of
-    [Timestamp, Id] -> Id;
+  RetVal = case string:tokens(binary_to_list(Username), ":") of
+    [Timestamp, Id] -> list_to_binary(Id);
     [Timestamp] -> undefined
   end,
   case still_valid(Timestamp) of

--- a/test/mojoauth_tests.erl
+++ b/test/mojoauth_tests.erl
@@ -38,18 +38,18 @@ create_secret_test() ->
 created_credentials_test_true_test() ->
   Secret = mojoauth:create_secret(),
   Credentials = mojoauth:create_credentials({secret, Secret}),
-  true = mojoauth:test_credentials(Credentials, Secret).
+  {ok,undefined} = mojoauth:test_credentials(Credentials, Secret).
 
 incorrect_password_tests_false_test() ->
   Secret = mojoauth:create_secret(),
   [{username, Username}, _] = mojoauth:create_credentials({secret, Secret}),
-  false = mojoauth:test_credentials([{username, Username}, {password, "foobar"}], Secret).
+  {invalid} = mojoauth:test_credentials([{username, Username}, {password, "foobar"}], Secret).
 
 different_secret_tests_false_test() ->
   Secret1 = mojoauth:create_secret(),
   Secret2 = mojoauth:create_secret(),
   Credentials = mojoauth:create_credentials({secret, Secret1}),
-  false = mojoauth:test_credentials(Credentials, Secret2).
+  {invalid} = mojoauth:test_credentials(Credentials, Secret2).
 
 attempt_extend_expiration_tests_false_test() ->
   Secret = mojoauth:create_secret(),
@@ -57,7 +57,7 @@ attempt_extend_expiration_tests_false_test() ->
   {Mega, Secs, _} = now(),
   Timestamp = Mega*1000000 + Secs,
   Username = integer_to_list(Timestamp + 10000),
-  false = mojoauth:test_credentials([{username, Username}, {password, Password}], Secret).
+  {invalid} = mojoauth:test_credentials([{username, Username}, {password, Password}], Secret).
 
 after_expiration_tests_false_test(Moka) ->
   Secret = mojoauth:create_secret(),
@@ -68,7 +68,7 @@ after_expiration_tests_false_test(Moka) ->
       {Mega, Secs + 86400 + 1, Micro}
     end),
   moka:load(Moka),
-  [?_assertEqual(false, mojoauth:test_credentials(Credentials, Secret))].
+  [?_assertEqual({expired}, mojoauth:test_credentials(Credentials, Secret))].
 
 after_custom_expiration_tests_false_test(Moka) ->
   Secret = mojoauth:create_secret(),
@@ -79,26 +79,26 @@ after_custom_expiration_tests_false_test(Moka) ->
       {Mega, Secs + 200 + 1, Micro}
     end),
   moka:load(Moka),
-  [?_assertEqual(false, mojoauth:test_credentials(Credentials, Secret))].
+  [?_assertEqual({expired}, mojoauth:test_credentials(Credentials, Secret))].
 
 asserted_id_created_credentials_return_id_test() ->
   Id = "foobar",
   Secret = mojoauth:create_secret(),
   Credentials = mojoauth:create_credentials({id, Id}, {secret, Secret}),
-  Id = mojoauth:test_credentials(Credentials, Secret).
+  {ok,Id} = mojoauth:test_credentials(Credentials, Secret).
 
 asserted_id_incorrect_password_tests_false_test() ->
   Id = "foobar",
   Secret = mojoauth:create_secret(),
   [{username, Username}, _] = mojoauth:create_credentials({id, Id}, {secret, Secret}),
-  false = mojoauth:test_credentials([{username, Username}, {password, "foobar"}], Secret).
+  {invalid} = mojoauth:test_credentials([{username, Username}, {password, "foobar"}], Secret).
 
 asserted_id_different_secret_tests_false_test() ->
   Id = "foobar",
   Secret1 = mojoauth:create_secret(),
   Secret2 = mojoauth:create_secret(),
   Credentials = mojoauth:create_credentials({id, Id}, {secret, Secret1}),
-  false = mojoauth:test_credentials(Credentials, Secret2).
+  {invalid} = mojoauth:test_credentials(Credentials, Secret2).
 
 asserted_id_attempt_extend_expiration_tests_false_test() ->
   Id = "foobar",
@@ -107,7 +107,7 @@ asserted_id_attempt_extend_expiration_tests_false_test() ->
   {Mega, Secs, _} = now(),
   Timestamp = Mega*1000000 + Secs,
   Username = string:join([integer_to_list(Timestamp + 10000), Id], ":"),
-  false = mojoauth:test_credentials([{username, Username}, {password, Password}], Secret).
+  {invalid} = mojoauth:test_credentials([{username, Username}, {password, Password}], Secret).
 
 asserted_id_after_expiration_tests_false_test(Moka) ->
   Id = "foobar",
@@ -119,7 +119,7 @@ asserted_id_after_expiration_tests_false_test(Moka) ->
       {Mega, Secs + 86400 + 1, Micro}
     end),
   moka:load(Moka),
-  [?_assertEqual(false, mojoauth:test_credentials(Credentials, Secret))].
+  [?_assertEqual({expired}, mojoauth:test_credentials(Credentials, Secret))].
 
 asserted_id_after_custom_expiration_tests_false_test(Moka) ->
   Id = "foobar",
@@ -131,4 +131,4 @@ asserted_id_after_custom_expiration_tests_false_test(Moka) ->
       {Mega, Secs + 200 + 1, Micro}
     end),
   moka:load(Moka),
-  [?_assertEqual(false, mojoauth:test_credentials(Credentials, Secret))].
+  [?_assertEqual({expired}, mojoauth:test_credentials(Credentials, Secret))].

--- a/test/mojoauth_tests.erl
+++ b/test/mojoauth_tests.erl
@@ -57,7 +57,7 @@ attempt_extend_expiration_tests_false_test() ->
   {Mega, Secs, _} = now(),
   Timestamp = Mega*1000000 + Secs,
   Username = integer_to_list(Timestamp + 10000),
-  {invalid} = mojoauth:test_credentials([{username, Username}, {password, Password}], Secret).
+  {invalid} = mojoauth:test_credentials([{username, list_to_binary(Username)}, {password, Password}], Secret).
 
 after_expiration_tests_false_test(Moka) ->
   Secret = mojoauth:create_secret(),
@@ -82,35 +82,35 @@ after_custom_expiration_tests_false_test(Moka) ->
   [?_assertEqual({expired}, mojoauth:test_credentials(Credentials, Secret))].
 
 asserted_id_created_credentials_return_id_test() ->
-  Id = "foobar",
+  Id = <<"foobar">>,
   Secret = mojoauth:create_secret(),
   Credentials = mojoauth:create_credentials({id, Id}, {secret, Secret}),
   {ok,Id} = mojoauth:test_credentials(Credentials, Secret).
 
 asserted_id_incorrect_password_tests_false_test() ->
-  Id = "foobar",
+  Id = <<"foobar">>,
   Secret = mojoauth:create_secret(),
   [{username, Username}, _] = mojoauth:create_credentials({id, Id}, {secret, Secret}),
   {invalid} = mojoauth:test_credentials([{username, Username}, {password, "foobar"}], Secret).
 
 asserted_id_different_secret_tests_false_test() ->
-  Id = "foobar",
+  Id = <<"foobar">>,
   Secret1 = mojoauth:create_secret(),
   Secret2 = mojoauth:create_secret(),
   Credentials = mojoauth:create_credentials({id, Id}, {secret, Secret1}),
   {invalid} = mojoauth:test_credentials(Credentials, Secret2).
 
 asserted_id_attempt_extend_expiration_tests_false_test() ->
-  Id = "foobar",
+  Id = <<"foobar">>,
   Secret = mojoauth:create_secret(),
   [_, {password, Password}] = mojoauth:create_credentials({id, Id}, {secret, Secret}),
   {Mega, Secs, _} = now(),
   Timestamp = Mega*1000000 + Secs,
   Username = string:join([integer_to_list(Timestamp + 10000), Id], ":"),
-  {invalid} = mojoauth:test_credentials([{username, Username}, {password, Password}], Secret).
+  {invalid} = mojoauth:test_credentials([{username, list_to_binary(Username)}, {password, Password}], Secret).
 
 asserted_id_after_expiration_tests_false_test(Moka) ->
-  Id = "foobar",
+  Id = <<"foobar">>,
   Secret = mojoauth:create_secret(),
   Credentials = mojoauth:create_credentials({id, Id}, {secret, Secret}),
   {Mega, Secs, Micro} = os:timestamp(),
@@ -122,7 +122,7 @@ asserted_id_after_expiration_tests_false_test(Moka) ->
   [?_assertEqual({expired}, mojoauth:test_credentials(Credentials, Secret))].
 
 asserted_id_after_custom_expiration_tests_false_test(Moka) ->
-  Id = "foobar",
+  Id = <<"foobar">>,
   Secret = mojoauth:create_secret(),
   Credentials = mojoauth:create_credentials({id, Id}, {ttl, 200}, {secret, Secret}),
   {Mega, Secs, Micro} = os:timestamp(),


### PR DESCRIPTION
Separate success from ID assertion

Allows better pattern matching:

``` erlang
case mojoauth:test_credentials(...) of
  {ok,undefined} ->
    %% Correct but no ID asserted
  {ok,Id} ->
    %% Correct with asserted ID
  {expired} ->
    %% Expired
  {invalid} ->
    %% Not yet expired but otherwise invalid
end
```

@polysics ?
